### PR TITLE
HC3 scenes fix

### DIFF
--- a/src/main/java/com/bwssystems/HABridge/plugins/fibaro/FibaroInfo.java
+++ b/src/main/java/com/bwssystems/HABridge/plugins/fibaro/FibaroInfo.java
@@ -155,7 +155,7 @@ public class FibaroInfo
 		if(isDevMode)
 			result = FibaroTestData.SceneTestData;
 		else
-			result = request("/api/scenes?enabled=true&visible=true");
+			result = request("/api/scenes");
 		log.debug("getScenes response: <<<" + result + ">>>");
 		Scene[] all_scenes = result == null ? new Scene[0] : gson.fromJson(result, Scene[].class);
 		


### PR DESCRIPTION
Updated the URI used to get scenes to work with HC3's updated API which has no query parameters other than "alexaProhibited".

